### PR TITLE
Add Circle CI configuration for build and deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,52 @@
+version: 2.1
+
+orbs:
+  python: circleci/python@2.1.1
+  ansible: trustedshops-public/ansible@2.0.0
+  codecov: codecov/codecov@3.2.4
+
+jobs:
+  build:
+    docker:
+      - image: cimg/python:3.11.3
+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "requirements.txt" }}
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}
+        
+      # run tests!
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            python manage.py test 
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports
+
+workflows:
+  build-and-deploy:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: /.*/
+      - build:
+          filters:
+            branches:
+              only: release
+        


### PR DESCRIPTION
Description:
This commit adds the Circle CI configuration file to the repository. The configuration file is set to version 2.1 and includes the following orbs: 'python' (circleci/python@2.1.1), 'ansible' (trustedshops-public/ansible@2.0.0), and 'codecov' (codecov/codecov@3.2.4).

The 'build' job is defined with a Docker image based on cimg/python:3.11.3. The steps within the job include checking out the repository, restoring cache for dependencies, installing dependencies using a virtual environment, saving the cache for future use, running tests using the Django management command, and storing test artifacts in the 'test-reports' directory.

The configuration also sets up a workflow named 'build-and-deploy' which includes the 'build' job with filters for all branches and branches with the 'release' pattern.

This Circle CI configuration will enable automated building and testing of the project, ensuring reliable and consistent deployments.