### PR TITLE
Add AppModelLoader class for loading Django app models

### DIFF
--- a/model_magic/app_loader.py
+++ b/model_magic/app_loader.py
@@ -1,0 +1,19 @@
+from django.apps import apps
+
+
+class AppModelLoader:
+    def __init__(self, app_name="_all_"):
+        self.app_name = app_name
+
+    def load_models(self):
+        if self.app_name == "_all_":
+            apps_with_models = [app for app in apps.get_app_configs() if app.get_models()] # noqa
+        else:
+            app = apps.get_app_config(self.app_name)
+            apps_with_models = [app] if app.get_models() else []
+
+        return tuple(
+            (app.name, model.__name__)
+            for app in apps_with_models
+            for model in app.get_models()
+        )


### PR DESCRIPTION
This commit introduces the AppModelLoader class in the model_magic/app_loader.py module. The class provides functionality to check if an app has models and store them in a tuple.

The AppModelLoader class takes an optional app_name argument, defaulting to all, which specifies the app to load models from. If all is provided, the class retrieves all app configurations and filters out the apps that have models. If a specific app_name is provided, the class checks if that app has models.

The load_models method is responsible for loading the models based on the specified app or all apps. It returns a tuple of (app_name, model_name) pairs representing the models found.